### PR TITLE
Bug fixes

### DIFF
--- a/soapfish/templates/lib
+++ b/soapfish/templates/lib
@@ -47,7 +47,7 @@ class {{ name|capitalize }}(xsd.List):
 class {{ attrGroup.name|capitalize }}(xsd.AttributeGroup):
     {%- for attribute in attrGroup.attributes %}
     {%- set name = attribute.ref|remove_namespace if attribute.ref else attribute.name %}
-    {{ name|fix_keyword }} = xsd.Attribute({{ attribute|type(known_types) }}{% if name in keywords %}, tagname='{{ name }}'{% endif %}{% if attribute.use %}, use={{ attribute.use|use }}{% endif %})
+    {{ name|fix_keyword }} = xsd.Attribute({{ attribute|type(known_types) }}{% if name in keywords %}, tagname='{{ name }}'{% endif %}, use={% if attribute.use %}{{ attribute.use|use }}{% else %}{{ 'optional'|use }}{% endif %})
     {%- endfor %}
 {# [blank line] #}
 {# [blank line] #}
@@ -123,7 +123,7 @@ class {{ class_name|capitalize }}(xsd.ComplexType):
 {%- endif %}
 {%- for attribute in content.attributes %}
     {%- set name = attribute.ref|remove_namespace if attribute.ref else attribute.name %}
-    {{ name|fix_keyword }} = xsd.Attribute({{ attribute|type(known_types) }}{% if name in keywords %}, tagname='{{ name }}'{% endif %}{% if attribute.use %}, use={{ attribute.use|use }}{% endif %})
+    {{ name|fix_keyword }} = xsd.Attribute({{ attribute|type(known_types) }}{% if name in keywords %}, tagname='{{ name }}'{% endif %}, use={% if attribute.use %}{{ attribute.use|use }}{% else %}{{ 'optional'|use }}{% endif %})
 {%- endfor %}
 {%- for attrGroupRef in content.attributeGroups %}
     {{ attrGroupRef.ref|remove_namespace }} = xsd.Ref({{ attrGroupRef.ref|type(known_types) }})

--- a/soapfish/testutil/generated_symbols.py
+++ b/soapfish/testutil/generated_symbols.py
@@ -12,20 +12,21 @@ __all__ = ['generated_symbols']
 def generated_symbols(code):
     from soapfish import xsd  # import may not be generated.
 
-    locals_ = dict(locals())
+    globals_ = {'xsd': xsd}
+    globals_old = dict(globals_)
 
     try:
         # Let's trust our own code generation...
-        six.exec_(code, {'xsd': xsd}, locals_)
+        six.exec_(code, globals_)
     except Exception:
         logging.warning('Code could not be imported:\n%s', code)
         raise
 
-    variables = set(locals_).difference(locals())
+    variables = set(globals_).difference(globals_old)
 
     schemas, symbols = [], {}
     for name in sorted(variables):
-        symbol = locals_[name]
+        symbol = globals_[name]
         symbols[name] = symbol
         if isinstance(symbol, xsd.Schema):
             schemas.append(symbol)

--- a/soapfish/testutil/generated_symbols.py
+++ b/soapfish/testutil/generated_symbols.py
@@ -2,11 +2,22 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import contextlib
 import logging
-
+import os
+import random
+import shutil
 import six
+import string
+import sys
+import tempfile
 
-__all__ = ['generated_symbols']
+try:
+    import importlib
+except ImportError:
+    importlib = None
+
+__all__ = ['generated_symbols', 'import_code']
 
 
 def generated_symbols(code):
@@ -18,7 +29,7 @@ def generated_symbols(code):
     try:
         # Let's trust our own code generation...
         six.exec_(code, globals_)
-    except Exception:
+    except Exception as ex:
         logging.warning('Code could not be imported:\n%s', code)
         raise
 
@@ -31,3 +42,28 @@ def generated_symbols(code):
         if isinstance(symbol, xsd.Schema):
             schemas.append(symbol)
     return schemas, symbols
+
+
+@contextlib.contextmanager
+def import_code(code):
+    code_module = None
+    tmp_dir = None
+    try:
+        if tmp_dir is None:
+            tmp_dir = tempfile.mkdtemp()
+        module_name = "import_code_" + ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(5))
+        with open(os.path.join(tmp_dir, module_name) + ".py", 'w+b') as f:
+            f.write(code)
+        sys.path.append(tmp_dir)
+        if importlib:
+            code_module = importlib.import_module(module_name)
+        else:
+            code_module = __import__(module_name, globals(), {})  # XXX: Python 2.6
+        yield code_module
+    finally:
+        if code_module is not None:
+            del code_module
+        if tmp_dir:
+            if tmp_dir in sys.path:
+                sys.path.remove(tmp_dir)
+            shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/soapfish/utils.py
+++ b/soapfish/utils.py
@@ -143,7 +143,7 @@ def get_rendering_environment(xsd_namespaces, module='soapfish'):
 
         if ns in xsd_namespaces:
             return 'xsd.%s' % capitalize(name)
-        elif known_types is not None and name in known_types:
+        elif known_types is not None and capitalize(name) in known_types:
             return '%s' % capitalize(name)
         else:
             return "__name__ + '.%s'" % capitalize(name)

--- a/tests/assets/generation/attrgroup_usage.xsd
+++ b/tests/assets/generation/attrgroup_usage.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="urn:ns1" targetNamespace="urn:ns1"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:attributeGroup name="sampleAttrs">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="value" type="xs:string"/>
+        <xs:attribute name="type" use="optional" type="xs:string"/>
+    </xs:attributeGroup>
+    <xs:complexType name="sampleType">
+        <xs:attributeGroup ref="tns:sampleAttrs"/>
+    </xs:complexType>
+</xs:schema>

--- a/tests/assets/generation/attribute_usage.xsd
+++ b/tests/assets/generation/attribute_usage.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:ns1"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:complexType name="sampleType">
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="value" type="xs:string"/>
+      <xs:attribute name="type" use="optional" type="xs:string"/>
+  </xs:complexType>
+</xs:schema>

--- a/tests/assets/generation/extension_with_special_chars.xsd
+++ b/tests/assets/generation/extension_with_special_chars.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://example.com" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:complexType name="ComplexType">
+    <xs:complexContent>
+      <xs:extension base="baseType_with_special_chars_123">
+        <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="0" name="Field3" type="xs:string"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="baseType_with_special_chars_123">
+    <!-- starting with lowercase letter and using some non-alphabetic characters to test
+         if corresponding Python class can still be found -->
+    <!-- TODO: add dash and dot to the type name as these are also legal in type name -->
+    <xs:sequence>
+      <xs:element name="Field1" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/tests/generation/code_test.py
+++ b/tests/generation/code_test.py
@@ -22,12 +22,12 @@ class CodeGenerationTest(unittest.TestCase):
             # -*- coding: utf-8 -*-
             import sys
             sys.path.append('{0}')
-        ''').format(os.path.dirname(fn)).encode('utf8')
+        ''').format(os.path.dirname(fn).replace('\\', '\\\\')).encode('utf8')
         code = header + b'\n' + code + b'\n'
         with open(fn, 'wb') as f:
             f.write(code)
         compile(code, fn, 'exec')
-        globalz['__name__'] = fn.rsplit('/', 1)[-1].rsplit('.', 1)[0]
+        globalz['__name__'] = os.path.basename(fn).rsplit('.', 1)[0]
         six.exec_(code, globalz)
 
     def _check_reparse_wsdl(self, base, target):

--- a/tests/generation/wsdl_code_test.py
+++ b/tests/generation/wsdl_code_test.py
@@ -46,7 +46,7 @@ class WSDLCodeGenerationTest(PythonicTestCase):
         code = wsdl2py.generate_code_from_wsdl(xml, 'client')
         schemas, symbols = generated_symbols(code)
         assert_is_not_empty(schemas)
-        assert_length(4, symbols)
+        assert_length(2, tuple(filter(lambda name: name.startswith("Schema_"), symbols)))
         assert_equals(['A'], list(schemas[0].elements))
         assert_equals(['B'], list(schemas[1].elements))
 

--- a/tests/generation/xsd_attrs_code_test.py
+++ b/tests/generation/xsd_attrs_code_test.py
@@ -1,0 +1,84 @@
+from lxml import etree
+from pythonic_testcase import (
+    PythonicTestCase,
+    assert_contains,
+    assert_equals,
+    assert_none,
+    assert_raises
+)
+
+from soapfish import utils, xsd2py
+from soapfish import testutil
+
+
+class ComplexTypeAttributeUsageGenerationTest(PythonicTestCase):
+    def setUp(self):
+        xsd_str = utils.open_document("tests/assets/generation/attribute_usage.xsd")
+        code = xsd2py.generate_code_from_xsd(xsd_str)
+        self.schemas, self.symbols = testutil.generated_symbols(code)
+        self.SampleType = self.symbols["SampleType"]
+
+    def test_can_specify_all_attributes(self):
+        instance = self.SampleType(name="someName", value="someValue", type="someType")
+        element = etree.Element("sample")
+        instance.render(element, instance)
+
+        assert_equals("someName", element.get("name"))
+        assert_equals("someType", element.get("type"))
+        assert_equals("someValue", element.get("value"))
+
+    def test_can_omit_optional_attributes(self):
+        instance = self.SampleType(name="someName")
+        element = etree.Element("sample")
+        instance.render(element, instance)
+
+        assert_equals("someName", element.get("name"))
+        assert_none(element.get("value"))
+        assert_none(element.get("type"))
+
+    def test_cannot_omit_required_attribute(self):
+        instance = self.SampleType(value="someValue", type="someType")
+        element = etree.Element("sample")
+
+        with assert_raises(ValueError) as context:
+            instance.render(element, instance)
+        # the exception raised should mention the field is required
+        assert_contains("required", str(context.caught_exception))
+
+
+class AttributeGroupUsageGenerationTest(PythonicTestCase):
+    def setUp(self):
+        xsd_str = utils.open_document("tests/assets/generation/attrgroup_usage.xsd")
+        self.code = xsd2py.generate_code_from_xsd(xsd_str)
+
+    def test_can_specify_all_attributes(self):
+        with testutil.import_code(self.code) as generated:
+            instance = generated.SampleType(
+                sampleAttrs=generated.SampleAttrs(name="someName", value="someValue", type="someType")
+            )
+            element = etree.Element("sample")
+            instance.render(element, instance)
+
+            assert_equals("someName", element.get("name"))
+            assert_equals("someType", element.get("type"))
+            assert_equals("someValue", element.get("value"))
+
+    def test_can_omit_optional_attributes(self):
+        with testutil.import_code(self.code) as generated:
+            instance = generated.SampleType(sampleAttrs=generated.SampleAttrs(name="someName"))
+            element = etree.Element("sample")
+            instance.render(element, instance)
+
+            assert_equals("someName", element.get("name"))
+            assert_none(element.get("value"))
+            assert_none(element.get("type"))
+
+    def test_cannot_omit_required_attribute(self):
+        with testutil.import_code(self.code) as generated:
+            instance = generated.SampleType(sampleAttrs=generated.SampleAttrs(value="someValue", type="someType"))
+            element = etree.Element("sample")
+
+            with assert_raises(ValueError) as context:
+                instance.render(element, instance)
+            # the exception raised should mention the field is required
+            assert_contains("required", str(context.caught_exception))

--- a/tests/generation/xsd_code_test.py
+++ b/tests/generation/xsd_code_test.py
@@ -136,3 +136,11 @@ class XSDCodeGenerationTest(PythonicTestCase):
         ct = symbols['ComplexType']
         ct.Field1
         ct.Field2
+
+    def test_can_generate_extension_of_type_with_special_chars(self):
+        xml = utils.open_document('tests/assets/generation/extension_with_special_chars.xsd')
+        code = xsd2py.generate_code_from_xsd(xml)
+        schemas, symbols = generated_symbols(code)
+        assert_true("BaseType_with_special_chars_123" in symbols)
+        assert_equals("BaseType_with_special_chars_123", symbols["ComplexType"].__base__.__name__)
+

--- a/tests/generation/xsd_code_test.py
+++ b/tests/generation/xsd_code_test.py
@@ -27,7 +27,7 @@ class XSDCodeGenerationTest(PythonicTestCase):
 
         schemas, symbols = generated_symbols(code)
         assert_is_not_empty(schemas)
-        assert_length(1, symbols)
+        assert_length(1, tuple(filter(lambda name: name.startswith("Schema_"), symbols)))
 
         assert_equals(['simpleElement'], list(schemas[0].elements))
         simple_element = schemas[0].elements['simpleElement']


### PR DESCRIPTION
This pull request contains following fixes:

* Tests in tests/generation/code_test.py didn't work on Windows. They should be OS independent now.
* Types declared in an XSD schema and starting with lower case letter could not be found in `known_types` list when another type extended them. This resulted in class definition `class Child(__name__ + '.BaseType')` that didn't compile.
* Passing a local variables dictionary to `six.exec_` was omitted in the `generated_symbols` function. The previous implementation evaluated the code as if declared inside a class, which caused problems with referencing global variables - code execution failed, even though the code was correct.
* Fix for [FlightDataServices/soapfish: #32](https://github.com/FlightDataServices/soapfish/issues/32). W3C's XSD schema specification says all element attributes are optional by default, but the `Attribute` class has `use` property set to _required_ by default. I changed Jinja templates to always set `Attribute`'s `use` property either to what is specified in the parsed schema, or to W3C's default.