### PR TITLE
requests SSL context with test and documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Contents:
 
     tutorial
     middlewares
+    sslcontext
 
 Indices and tables
 ==================

--- a/docs/sslcontext.rst
+++ b/docs/sslcontext.rst
@@ -1,0 +1,43 @@
+Mutual authentication with SSL
+===============================
+
+Consume service throug SSL is possible in soapfish, we use requests so you can expecify environment variables to change the behaivor of request in ssl context.
+
+Possible variables:
+
+- `REQUESTS_CA_CHECK` if false, don't verify the certificate 
+- `REQUESTS_CA_PATH` set the Autority Certificate to be used to check certificates
+- `REQUESTS_CERT_PATH` set path to certificate.
+- `REQUESTS_KEY_PATH` set path to private key used to encript message
+
+Also it's possible to set only `REQUESTS_CERT_PATH` in pem format with private key and certify without REQUESTS_KEY_PATH
+
+.. warning:: Both get and post method are cover with environment variables
+
+Using as Stub arguments
+-------------------------
+
+You can specify the same variables on stub class
+
+.. code-block:: python
+
+    class MyServiceStub(soap.Stub):
+        SERVICE = SERVICE
+        SCHEME = 'https'
+        HOST = 'example.com'
+        REQUESTS_CA_CHECK= False
+
+or including mutual authenticacion with known Autority Certificate.
+
+
+.. code-block:: python
+
+    class MyServiceStub(soap.Stub):
+        SERVICE = SERVICE
+        SCHEME = 'https'
+        HOST = 'example.com'
+        REQUESTS_CA_PATH='/path/to/ca.crt'
+        REQUESTS_CERT_PATH='/path/to/certificate.crt'
+        REQUESTS_KEY_PATH='/path/to/key.pem'
+
+.. warning:: The private key to your local certificate must be unencrypted. Currently, Requests does not support using encrypted keys.

--- a/soapfish/soap.py
+++ b/soapfish/soap.py
@@ -12,7 +12,7 @@ import requests
 import six
 
 from . import core, namespaces as ns, soap11, soap12, wsa
-from .utils import uncapitalize
+from .utils import uncapitalize, get_requests_ssl_context
 
 SOAP_HTTP_Transport = ns.wsdl_soap_http
 
@@ -162,7 +162,13 @@ class Stub(object):
         logger.info("Call '%s' on '%s'", operationName, self.location)
         logger.debug('Request Headers: %s', headers)
         logger.debug('Request Envelope: %s', data)
-        r = requests.post(self.location, auth=auth, headers=headers, data=data)
+        kwargs={
+            'auth': auth, 
+            'headers': headers, 
+            'data': data
+        }
+        kwargs.update(get_requests_ssl_context(self))
+        r = requests.post(self.location, **kwargs)
         logger.debug('Response Headers: %s', r.headers)
         logger.debug('Response Envelope: %s', r.content)
         return self._handle_response(method, r.headers, r.content)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -2,10 +2,16 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 
-from pythonic_testcase import PythonicTestCase, assert_equals
+from pythonic_testcase import PythonicTestCase, assert_equals, assert_dict_contains, \
+                            assert_false, assert_contains
 
-from soapfish.utils import timezone_offset_to_string
-
+from soapfish.utils import timezone_offset_to_string, get_requests_ssl_context
+from soapfish import soap
+import os
+try:
+    from test.test_support import EnvironmentVarGuard
+except:
+    from test.support import EnvironmentVarGuard
 
 class FormatOffsetTest(PythonicTestCase):
     def test_can_format_positive_offsets(self):
@@ -17,3 +23,86 @@ class FormatOffsetTest(PythonicTestCase):
         assert_equals('-00:30', timezone_offset_to_string(timedelta(minutes=-30)))
         assert_equals('-01:30', timezone_offset_to_string(timedelta(minutes=-90)))
         assert_equals('-14:00', timezone_offset_to_string(timedelta(hours=-14)))
+
+
+class SSLExtraContextsetTest(PythonicTestCase):
+
+    def test_verify_false(self):
+        class NoSSLCheckStub(soap.Stub):
+            SERVICE = None
+            SCHEME = 'https'
+            HOST = 'example.com'        
+            REQUESTS_CA_CHECK=False
+
+            def __init__(*args, **kwargs):
+                pass
+        
+        context = get_requests_ssl_context(NoSSLCheckStub())
+        assert_contains('verify', context )
+        assert_false(context['verify'])
+
+    def test_environment_verify_false(self):
+        context = {}
+        env = EnvironmentVarGuard()
+        env.set('REQUESTS_CA_CHECK', 'False')
+        with env:
+            context = get_requests_ssl_context()
+        assert_contains('verify', context )
+        assert_false(context['verify'])
+
+    def test_provide_CA_Certs(self):
+
+        class MyServiceStub(soap.Stub):
+            SERVICE = None
+            SCHEME = 'https'
+            HOST = 'example.com'
+            REQUESTS_CA_PATH='/path/to/ca.crt'
+            REQUESTS_CERT_PATH='/path/to/certificate.crt'
+            REQUESTS_KEY_PATH='/path/to/key.pem'
+
+            def __init__(*args, **kwargs):
+                pass
+
+
+        context = get_requests_ssl_context(MyServiceStub())
+        assert_dict_contains( {'verify': '/path/to/ca.crt',
+                                  'cert': ('/path/to/certificate.crt', 
+                                           '/path/to/key.pem')
+                              }, context)
+
+
+    def test_environment_provide_CA_Certs(self):
+        context={}
+        env = EnvironmentVarGuard()
+        env.set('REQUESTS_CA_PATH', '/path/to/ca.crt')
+        env.set('REQUESTS_CERT_PATH', '/path/to/certificate.crt')
+        env.set('REQUESTS_KEY_PATH', '/path/to/key.pem')
+        with env:
+           context = get_requests_ssl_context()
+        assert_dict_contains( {'verify': '/path/to/ca.crt',
+                                  'cert': ('/path/to/certificate.crt', 
+                                           '/path/to/key.pem')
+                              }, context)
+
+
+    def test_provide_Cert_PEM(self):
+        class MyServiceStub(soap.Stub):
+            SERVICE = None
+            SCHEME = 'https'
+            HOST = 'example.com'
+            REQUESTS_CERT_PATH='/path/to/certificate.pem'
+
+            def __init__(*args, **kwargs):
+                pass
+
+        context = get_requests_ssl_context(MyServiceStub())
+        assert_dict_contains({'cert': '/path/to/certificate.pem' }, context)
+
+    def test_environment_provide_Cert_PEM(self):
+        conext={}
+        env = EnvironmentVarGuard()
+        env.set('REQUESTS_CERT_PATH', '/path/to/certificate.pem')
+        with env:
+            context = get_requests_ssl_context()
+        assert_dict_contains({'cert': '/path/to/certificate.pem' }, context)
+


### PR DESCRIPTION
Incorporate the possibility of interact with service throug SSL in soapfish,  the lib use requests so you can specify environment variables to change the behavior of request in ssl context.

Possible variables:

- `REQUESTS_CA_CHECK` if false, don't verify the certificate 
- `REQUESTS_CA_PATH` set the Autority Certificate to be used to check certificates
- `REQUESTS_CERT_PATH` set path to certificate.
- `REQUESTS_KEY_PATH` set path to private key used to encript message

Also it's possible to set only `REQUESTS_CERT_PATH` in pem format with private key and certify without REQUESTS_KEY_PATH

Using as Stub arguments
-------------------------

You can specify the same variables on stub class

    class MyServiceStub(soap.Stub):
        SERVICE = SERVICE
        SCHEME = 'https'
        HOST = 'example.com'
        REQUESTS_CA_CHECK= False

or including mutual authenticacion with known Autority Certificate.

    class MyServiceStub(soap.Stub):
        SERVICE = SERVICE
        SCHEME = 'https'
        HOST = 'example.com'
        REQUESTS_CA_PATH='/path/to/ca.crt'
        REQUESTS_CERT_PATH='/path/to/certificate.crt'
        REQUESTS_KEY_PATH='/path/to/key.pem'

**warning** The private key to your local certificate must be unencrypted. Currently, Requests does not support using encrypted keys.