### PR TITLE
tree-wide: use httpx instead of requests.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Changes
 =======
 
-0.6.0 (2020-??-??)
+0.6.0 (2021-??-??)
 ------------------
 
 Project has been renamed to `soapfish` to distinguish it from the legacy
@@ -24,7 +24,7 @@ the `soapfish` fork.
     - _Patch contributed by Martin Mrose, tests written by Felix Schwarz_
   - Implemented a dispatcher for Flask (#53)
   - Implement service.route function to avoid changes to generated code (#68)
-  - Changed to use `requests` instead of `httplib2`.
+  - Changed to use ~~`requests`~~ `httpx` instead of `httplib2`.
   - Added support for multiple inline schema imports and includes.
   - Added support for import of other WSDL documents.
   - Support for reordering of schema imports and includes and handle circular imports.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,10 +40,10 @@ include_package_data = true
 packages = find:
 python_requires = >=3.6
 install_requires =
+    httpx
     iso8601>=0.1.12
     jinja2
     lxml
-    requests
 
 [options.packages.find]
 exclude = examples, tests, tests.*

--- a/soapfish/soap.py
+++ b/soapfish/soap.py
@@ -3,7 +3,7 @@
 import logging
 import string
 
-import requests
+import httpx
 
 from . import core, namespaces as ns, soap11, soap12, wsa
 from .utils import uncapitalize
@@ -134,7 +134,7 @@ class Stub:
         logger.info("Call '%s' on '%s'", operationName, self.location)
         logger.debug('Request Headers: %s', headers)
         logger.debug('Request Envelope: %s', data)
-        r = requests.post(self.location, auth=auth, headers=headers, data=data)
+        r = httpx.post(self.location, auth=auth, headers=headers, data=data)
         logger.debug('Response Headers: %s', r.headers)
         logger.debug('Response Envelope: %s', r.content)
         return self._handle_response(method, r.headers, r.content)

--- a/soapfish/utils.py
+++ b/soapfish/utils.py
@@ -7,7 +7,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse, urlunparse
 
-import requests
+import httpx
 from jinja2 import Environment, PackageLoader
 
 from . import namespaces as ns
@@ -29,7 +29,7 @@ def resolve_location(path, cwd):
 def open_document(path):
     if '://' in path:
         logger.info('Opening remote document: %s', path)
-        return requests.get(path).content
+        return httpx.get(path).content
     else:
         logger.info('Opening local document: %s', path)
         with open(path, 'rb') as f:


### PR DESCRIPTION
This is largely a drop-in replacement and may be useful in the future for supporting async requests.