### PR TITLE
Various updates to package versions, workflows, etc.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,14 +23,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Determine pip cache directory
-      id: pip-cache
-      run: echo "::set-output name=dir::$(pip cache dir)"
-    - name: Persist pip cache directory
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-${{ matrix.python }}-pip-${{ hashFiles('tests/requirements/lint.txt') }}
+        cache: pip
+        cache-dependency-path: tests/requirements/lint.txt
     - name: Install dependencies
       run: pip install --requirement=tests/requirements/lint.txt
     - name: Run linters

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python: ['3.9']
+        python: ['3.10']
     steps:
     - name: Check out source
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Determine pip cache directory
-      id: pip-cache
-      run: echo "::set-output name=dir::$(pip cache dir)"
-    - name: Persist pip cache directory
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-${{ matrix.python }}-pip-${{ hashFiles('tests/requirements/test.txt') }}
+        cache: pip
+        cache-dependency-path: tests/requirements/test.txt
     - name: Install dependencies
       run: pip install --requirement=tests/requirements/test.txt --editable=. ${{ matrix.framework }}
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python: ['3.7', '3.8', '3.9']
-        framework: ['django~=2.2.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
+        framework: ['django~=2.2.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
         exclude:
           - os: 'ubuntu-latest'
             python: '3.7'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
         framework: ['django~=3.2.0', 'django~=4.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
         exclude:
           - os: 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,8 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python: ['3.7', '3.8', '3.9']
-        framework: ['django~=1.11.0', 'django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
+        framework: ['django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
         exclude:
-          - os: 'ubuntu-latest'
-            python: '3.8'
-            framework: 'django~=1.11.0'
-          - os: 'ubuntu-latest'
-            python: '3.9'
-            framework: 'django~=1.11.0'
           - os: 'ubuntu-latest'
             python: '3.7'
             framework: 'django~=4.0.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python: ['3.7', '3.8', '3.9']
-        framework: ['django~=2.2.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
+        framework: ['django~=3.2.0', 'django~=4.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
         exclude:
           - os: 'ubuntu-latest'
             python: '3.7'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python: ['3.7', '3.8', '3.9']
-        framework: ['django~=1.11.0', 'django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'django~=3.2.0', 'flask~=1.0.0', 'flask~=1.1.0']
+        framework: ['django~=1.11.0', 'django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0']
         exclude:
           - os: 'ubuntu-latest'
             python: '3.8'
@@ -24,6 +24,9 @@ jobs:
           - os: 'ubuntu-latest'
             python: '3.9'
             framework: 'django~=1.11.0'
+          - os: 'ubuntu-latest'
+            python: '3.7'
+            framework: 'django~=4.0.0'
     steps:
     - name: Check out source
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python: ['3.7', '3.8', '3.9']
-        framework: ['django~=1.11.0', 'django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0']
+        framework: ['django~=1.11.0', 'django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
         exclude:
           - os: 'ubuntu-latest'
             python: '3.8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python: ['3.7', '3.8', '3.9']
-        framework: ['django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
+        framework: ['django~=2.2.0', 'django~=3.1.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
         exclude:
           - os: 'ubuntu-latest'
             python: '3.7'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python: ['3.7', '3.8', '3.9']
-        framework: ['django~=1.11.0', 'django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'flask~=1.0.0', 'flask~=1.1.0']
+        framework: ['django~=1.11.0', 'django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'django~=3.2.0', 'flask~=1.0.0', 'flask~=1.1.0']
         exclude:
           - os: 'ubuntu-latest'
             python: '3.8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python: ['3.7', '3.8', '3.9']
-        framework: ['django~=2.2.0', 'django~=3.1.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
+        framework: ['django~=2.2.0', 'django~=3.2.0', 'django~=4.0.0', 'flask~=1.0.0', 'flask~=1.1.0', 'flask~=2.0.0']
         exclude:
           - os: 'ubuntu-latest'
             python: '3.7'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9']
         framework: ['django~=1.11.0', 'django~=2.2.0', 'django~=3.0.0', 'django~=3.1.0', 'flask~=1.0.0', 'flask~=1.1.0']
         exclude:
           - os: 'ubuntu-latest'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ the `soapfish` fork.
   - Attempts to fix handling of remote vs local imports.
 - **Miscellaneous:**
   - Renamed `SoapboxRequest` and `SoapboxResponse` to `SOAPRequest` and `SOAPResponse` respectively.
-  - Support Python 3.7+, Django 1.11, 2.2, 3.0 & 3.1, and Flask 1.0.0+
+  - Support Python 3.7+, Django 1.11, 2.2, 3.0, 3.1 & 3.2, and Flask 1.0.0+
   - Improved testing against different versions of Python, Django & Flask.
   - Improved entry points for generation scripts - additional flags, etc.
   - Moved to using an external dependency for `iso8601`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ the `soapfish` fork.
   - Attempts to fix handling of remote vs local imports.
 - **Miscellaneous:**
   - Renamed `SoapboxRequest` and `SoapboxResponse` to `SOAPRequest` and `SOAPResponse` respectively.
-  - Support Python 3.7+, Django 1.11, 2.2, 3.0, 3.1, 3.2 & 4.0, and Flask 1.0, 1.1 & 2.0
+  - Support Python 3.7+, Django 2.2, 3.0, 3.1, 3.2 & 4.0, and Flask 1.0, 1.1 & 2.0
   - Improved testing against different versions of Python, Django & Flask.
   - Improved entry points for generation scripts - additional flags, etc.
   - Moved to using an external dependency for `iso8601`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ the `soapfish` fork.
   - Attempts to fix handling of remote vs local imports.
 - **Miscellaneous:**
   - Renamed `SoapboxRequest` and `SoapboxResponse` to `SOAPRequest` and `SOAPResponse` respectively.
-  - Support Python 3.7+, Django 2.2, 3.1, 3.2 & 4.0, and Flask 1.0, 1.1 & 2.0
+  - Support Python 3.7+, Django 2.2, 3.2 & 4.0, and Flask 1.0, 1.1 & 2.0
   - Improved testing against different versions of Python, Django & Flask.
   - Improved entry points for generation scripts - additional flags, etc.
   - Moved to using an external dependency for `iso8601`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ the `soapfish` fork.
   - Attempts to fix handling of remote vs local imports.
 - **Miscellaneous:**
   - Renamed `SoapboxRequest` and `SoapboxResponse` to `SOAPRequest` and `SOAPResponse` respectively.
-  - Support Python 3.7+, Django 2.2, 3.2 & 4.0, and Flask 1.1 & 2.0
+  - Support Python 3.7+, Django 3.2 & 4.0, and Flask 1.1 & 2.0
   - Improved testing against different versions of Python, Django & Flask.
   - Improved entry points for generation scripts - additional flags, etc.
   - Moved to using an external dependency for `iso8601`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ the `soapfish` fork.
   - Attempts to fix handling of remote vs local imports.
 - **Miscellaneous:**
   - Renamed `SoapboxRequest` and `SoapboxResponse` to `SOAPRequest` and `SOAPResponse` respectively.
-  - Support Python 3.7+, Django 2.2, 3.2 & 4.0, and Flask 1.0, 1.1 & 2.0
+  - Support Python 3.7+, Django 2.2, 3.2 & 4.0, and Flask 1.1 & 2.0
   - Improved testing against different versions of Python, Django & Flask.
   - Improved entry points for generation scripts - additional flags, etc.
   - Moved to using an external dependency for `iso8601`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ the `soapfish` fork.
   - Attempts to fix handling of remote vs local imports.
 - **Miscellaneous:**
   - Renamed `SoapboxRequest` and `SoapboxResponse` to `SOAPRequest` and `SOAPResponse` respectively.
-  - Support Python 3.6+, Django 1.11, 2.2, 3.0 & 3.1, and Flask 1.0.0+
+  - Support Python 3.7+, Django 1.11, 2.2, 3.0 & 3.1, and Flask 1.0.0+
   - Improved testing against different versions of Python, Django & Flask.
   - Improved entry points for generation scripts - additional flags, etc.
   - Moved to using an external dependency for `iso8601`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ the `soapfish` fork.
   - Attempts to fix handling of remote vs local imports.
 - **Miscellaneous:**
   - Renamed `SoapboxRequest` and `SoapboxResponse` to `SOAPRequest` and `SOAPResponse` respectively.
-  - Support Python 3.7+, Django 1.11, 2.2, 3.0, 3.1 & 3.2, and Flask 1.0.0+
+  - Support Python 3.7+, Django 1.11, 2.2, 3.0, 3.1, 3.2 & 4.0, and Flask 1.0.0+
   - Improved testing against different versions of Python, Django & Flask.
   - Improved entry points for generation scripts - additional flags, etc.
   - Moved to using an external dependency for `iso8601`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ the `soapfish` fork.
   - Attempts to fix handling of remote vs local imports.
 - **Miscellaneous:**
   - Renamed `SoapboxRequest` and `SoapboxResponse` to `SOAPRequest` and `SOAPResponse` respectively.
-  - Support Python 3.7+, Django 1.11, 2.2, 3.0, 3.1, 3.2 & 4.0, and Flask 1.0.0+
+  - Support Python 3.7+, Django 1.11, 2.2, 3.0, 3.1, 3.2 & 4.0, and Flask 1.0, 1.1 & 2.0
   - Improved testing against different versions of Python, Django & Flask.
   - Improved entry points for generation scripts - additional flags, etc.
   - Moved to using an external dependency for `iso8601`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@ the `soapfish` fork.
   - Attempts to fix handling of remote vs local imports.
 - **Miscellaneous:**
   - Renamed `SoapboxRequest` and `SoapboxResponse` to `SOAPRequest` and `SOAPResponse` respectively.
-  - Support Python 3.7+, Django 2.2, 3.0, 3.1, 3.2 & 4.0, and Flask 1.0, 1.1 & 2.0
+  - Support Python 3.7+, Django 2.2, 3.1, 3.2 & 4.0, and Flask 1.0, 1.1 & 2.0
   - Improved testing against different versions of Python, Django & Flask.
   - Improved entry points for generation scripts - additional flags, etc.
   - Moved to using an external dependency for `iso8601`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ generated code, it is recommended that you check out [Zeep](https://pypi.org/pro
 Introduction
 ------------
 
-Soapfish is a library to use SOAP services in Python. The server-side component can be used with Django, Flask, Pyramid
+Soapfish is a library to use SOAP services in Python. The server-side component can be used with Django & Flask
 and other frameworks (including plain WSGI). The library can also be used to implement SOAP clients.
 
 The library can help parsing/serializing a Python class model from/to XML and a bare-bones SOAP client.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Currently the project supports the following:
 
 Other notable features include:
 
-- Support for Python 3.6+
+- Support for Python 3.7+
 - Licensed under the 3-clause BSD license
 - Code generation utilities to get started quickly
 - Parsing/serializing a Python class model from/to XML so you can easily work

--- a/examples/stock/urls.py
+++ b/examples/stock/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import path
 
 urlpatterns = [
-    url(r'^stock/soap11$', 'stock.web.views.dispatch11'),
-    url(r'^stock/soap12$', 'stock.web.views.dispatch12'),
-    url(r'^ws/ops$', 'stock.web.views.ops_dispatch'),
+    path('stock/soap11', 'stock.web.views.dispatch11'),
+    path('stock/soap12', 'stock.web.views.dispatch12'),
+    path('ws/ops', 'stock.web.views.ops_dispatch'),
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,10 @@ classifiers =
     Environment :: Console
     Environment :: Web Environment
     Framework :: Django
+    Framework :: Django :: 1.11
+    Framework :: Django :: 2.2
+    Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
     Framework :: Flask
     Framework :: Pyramid
     Intended Audience :: Developers

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Framework :: Django :: 3.0
     Framework :: Django :: 3.1
     Framework :: Flask
-    Framework :: Pyramid
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Framework :: Django :: 3.1
+    Framework :: Django :: 3.2
     Framework :: Flask
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Environment :: Web Environment
     Framework :: Django
     Framework :: Django :: 2.2
-    Framework :: Django :: 3.0
     Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Environment :: Web Environment
     Framework :: Django
     Framework :: Django :: 2.2
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Flask

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Framework :: Django :: 3.0
     Framework :: Django :: 3.1
     Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
     Framework :: Flask
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Environment :: Console
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.2
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Flask

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -41,7 +40,7 @@ classifiers =
 zip_safe = false
 include_package_data = true
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     httpx
     iso8601>=0.1.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Internet :: WWW/HTTP
     Topic :: Software Development :: Libraries :: Python Modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Environment :: Console
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 1.11
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Framework :: Django :: 3.1

--- a/tests/framework/django_test.py
+++ b/tests/framework/django_test.py
@@ -21,8 +21,8 @@ else:
         USE_I18N=False,
         USE_TZ=True,
     )
-    from django.conf.urls import url
     from django.test import Client
+    from django.urls import path
 
 urlconf = collections.namedtuple('urlconf', 'urlpatterns')
 
@@ -32,7 +32,7 @@ class DjangoDispatchTest(framework.DispatchTestMixin, unittest.TestCase):
 
     def setUp(self):  # noqa
         self.service = echo_service()
-        settings.ROOT_URLCONF = urlconf(urlpatterns=(url(r'^ws/$', django_dispatcher(self.service)),))
+        settings.ROOT_URLCONF = urlconf(urlpatterns=(path('ws/', django_dispatcher(self.service)),))
         self.client = Client()
 
     def _prepare_extras(self, headers):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39
+envlist = py37, py38, py39, py310
 
 [testenv]
 commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
- Use `cache: pip` in GitHub Actions
- Drop support for Python < 3.7, Django < 3.2, Flask < 1.1
- Add support for Python 3.10, Django 3.2 & 4.0, Flask 2.0
- Remove references to Pyramid. _(There are no tests, so no idea if anything even works.)_
- Other minor bits of tidying for packaging.